### PR TITLE
Add feature selectors

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,17 +1,19 @@
 using Documenter
 using XAIBase
 
-makedocs(
-    modules = [XAIBase],
+makedocs(;
+    modules  = [XAIBase],
     sitename = "XAIBase.jl",
-    authors="Adrian Hill",
-    format=Documenter.HTML(; prettyurls=get(ENV, "CI", "false") == "true", assets=String[]),
-    pages=[
+    authors  = "Adrian Hill",
+    format   = Documenter.HTML(; prettyurls=get(ENV, "CI", "false") == "true", assets=String[]),
+    #! format: off
+    pages = [
         "XAIBase Interface" => "index.md",
-        "API Reference"     => "api.md",
+        "API Reference"     => "api.md"
     ],
-    linkcheck=true,
-    checkdocs=:exports, # only check docstrings in API reference if they are exported
+    #! format: on
+    linkcheck = true,
+    checkdocs = :exports, # only check docstrings in API reference if they are exported
 )
 
 deploydocs(; repo="github.com/Julia-XAI/XAIBase.jl")

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -15,6 +15,12 @@ Explanation
 heatmap
 ```
 
+## Feature selection
+```@docs
+IndexedFeatures
+TopNFeatures
+```
+
 ## Internals
 Neuron selectors:
 ```@docs

--- a/src/XAIBase.jl
+++ b/src/XAIBase.jl
@@ -29,6 +29,9 @@ include("analyze.jl")
 # Heatmapping for vision and NLP tasks.
 include("heatmaps.jl")
 
+# Utilities for XAI methods that compute Explanations w.r.t. specific features:
+include("feature_selection.jl")
+
 # To be removed in next breaking release:
 include("deprecated.jl")
 
@@ -37,4 +40,5 @@ export AbstractNeuronSelector
 export Explanation
 export analyze
 export heatmap
+export IndexedFeatures, TopNFeatures
 end #module

--- a/src/feature_selection.jl
+++ b/src/feature_selection.jl
@@ -1,0 +1,120 @@
+abstract type AbstractFeatureSelector end
+
+# Expected interfaces:
+# - Calls to feature selector that return a list of lists of CartesianIndices
+#   - (c::FeatureSelector)(R::AbstractArray{T,N}) where {T,2}
+#   - (c::FeatureSelector)(R::AbstractArray{T,N}) where {T,4}
+# - number_of_features(c::FeatureSelector)
+
+"""
+    IndexedFeatures(indices...)
+
+Select features by indices.
+
+For outputs of convolutional layers, the index refers to a feature dimension.
+
+See also See also [`TopNFeatures`](@ref).
+"""
+struct IndexedFeatures{N} <: AbstractFeatureSelector
+    inds::NTuple{N,Int}
+
+    function IndexedFeatures(inds::NTuple{N}) where {N}
+        for i in inds
+            i > 0 || throw(ArgumentError("All indices have to be greater than 0"))
+        end
+        return new{N}(inds)
+    end
+end
+IndexedFeatures(args...) = IndexedFeatures(tuple(args...))
+
+number_of_features(c::IndexedFeatures) = length(c.inds)
+
+# Pretty printing
+Base.show(io::IO, c::IndexedFeatures) = print(io, "IndexedFeatures$(c.inds)")
+
+# Index features on 2D arrays, e.g. Dense layers with batch dimension
+function (c::IndexedFeatures)(A::AbstractMatrix)
+    batchsize = size(A, 2)
+    return [[CartesianIndices((i:i, b:b)) for b in 1:batchsize] for i in c.inds]
+end
+
+# Index features on 4D arrays, e.g. Conv layers with batch dimension
+function (c::IndexedFeatures)(A::AbstractArray{T,4}) where {T}
+    w, h, _c, batchsize = size(A)
+    return [[CartesianIndices((1:w, 1:h, i:i, b:b)) for b in 1:batchsize] for i in c.inds]
+end
+
+"""
+    TopNFeatures(n)
+
+Select top-n features.
+
+For outputs of convolutional layers, the relevance is summed across height and width
+channels for each feature.
+
+See also [`IndexedFeatures`](@ref).
+"""
+struct TopNFeatures <: AbstractFeatureSelector
+    n::Int
+
+    function TopNFeatures(n)
+        n > 0 || throw(ArgumentError("n has to be greater than 0"))
+        return new(n)
+    end
+end
+
+number_of_features(c::TopNFeatures) = c.n
+
+# Extract top features from 2D arrays, e.g. Dense layers with batch dimension
+function (c::TopNFeatures)(A::AbstractMatrix)
+    n_features = size(A, 1)
+    c.n > n_features && throw(TopNDimensionError(c.n, n_features))
+
+    inds = top_n(A, c.n)
+    return [
+        [CartesianIndices((i:i, b:b)) for (b, i) in enumerate(r)] for r in eachrow(inds)
+    ]
+end
+
+# Extract top features from 4D array: e.g. Conv layers with batch dimension
+function (c::TopNFeatures)(A::AbstractArray{T,4}) where {T}
+    w, h, n_features, _batchsize = size(A)
+    c.n > n_features && throw(TopNDimensionError(c.n, n_features))
+
+    features = sum(A; dims=(1, 2))[1, 1, :, :] # reduce width and height channels
+    inds = top_n(features, c.n)
+    return [
+        [CartesianIndices((1:w, 1:h, i:i, b:b)) for (b, i) in enumerate(r)] for
+        r in eachrow(inds)
+    ]
+end
+
+function TopNDimensionError(n, nf)
+    DimensionMismatch(
+        "Attempted to find top $n features, but feature dimensionality is $nf"
+    )
+end
+
+"""
+    top_n(A, n)
+
+For a matrix `A` of size `(rows, batchdims)`, return a matrix of indices of size `(n, batchdims)`
+with sorted indices of the top-n entries.
+
+## Example
+```julia-repl
+julia> A = rand(4, 3)
+4×3 Matrix{Float64}:
+ 0.469809  0.740177  0.100856
+ 0.96932   0.53207   0.954989
+ 0.456456  0.837788  0.313662
+ 0.925512  0.556236  0.0366143
+
+julia> top_n(A, 2)
+2×3 Matrix{Int64}:
+ 2  3  2
+ 4  1  3
+```
+"""
+top_n(A::AbstractMatrix, n) = mapslices(x -> top_n(x, n), A; dims=1)
+top_n(x::AbstractArray, n) = sortperm(x; rev=true)[1:n]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,10 @@ using Aqua
         @info "Testing neuron selection..."
         include("test_neuron_selection.jl")
     end
+    @testset "Feature selection" begin
+        @info "Testing feature selection..."
+        include("test_feature_selection.jl")
+    end
     @testset "Vision heatmaps" begin
         @info "Testing vision heatmaps..."
         include("test_heatmap.jl")

--- a/test/test_feature_selection.jl
+++ b/test/test_feature_selection.jl
@@ -1,0 +1,74 @@
+@testset "Feature selectors" begin
+    @testset "API" begin
+        features = TopNFeatures(15)
+        @test XAIBase.number_of_features(features) == 15
+        features = IndexedFeatures(1:16...)
+        @test XAIBase.number_of_features(features) == 16
+
+        @test_throws DimensionMismatch (TopNFeatures(4))(rand(3, 5))
+        @test_throws DimensionMismatch (TopNFeatures(4))(rand(5, 5, 3, 5))
+    end
+    @testset "2D input batches" begin
+        R = [
+            0.360588  0.180214
+            0.721713  0.769733
+            0.242516  0.918393
+            0.736286  0.907605
+        ]
+
+        features = TopNFeatures(2)
+        c1, c2 = features(R)
+        @test R[c1[1]] ≈ [0.736286;;] # using ≈ for Julia 1.6 compatibility
+        @test R[c1[2]] ≈ [0.918393;;]
+        @test R[c2[1]] ≈ [0.721713;;]
+        @test R[c2[2]] ≈ [0.907605;;]
+
+        features = IndexedFeatures(3, 2)
+        c1, c2 = features(R)
+        @test R[c1[1]] ≈ [0.242516;;]
+        @test R[c1[2]] ≈ [0.918393;;]
+        @test R[c2[1]] ≈ [0.721713;;]
+        @test R[c2[2]] ≈ [0.769733;;]
+    end
+    @testset "4D input batches" begin
+        R = [
+            0.520093 0.106578 0.943595 0.286332
+            0.185124 0.624013 0.628282 0.068466
+            0.988973 0.083252 0.833007 0.321842
+            0.953506 0.687441 0.060545 0.502339
+            0.521664 0.717311 0.698516 0.069322
+            0.268384 0.920477 0.674791 0.748541
+            0.663752 0.270196 0.904576 0.263793
+            0.426357 0.090217 0.378728 0.543824
+        ]
+        R = reshape(R, 2, 2, 4, 2)
+
+        # Check top activated features:
+
+        # julia> sum(R; dims=(1, 2))
+        # 1×1×4×2 Array{Float64, 4}:
+        # [:, :, 1, 1] = 2.647696 # 1
+        # [:, :, 2, 1] = 1.880157
+        # [:, :, 3, 1] = 1.501284
+        # [:, :, 4, 1] = 1.998201 # 2
+
+        # [:, :, 1, 2] = 2.465429 # 2
+        # [:, :, 2, 2] = 2.656611 # 1
+        # [:, :, 3, 2] = 1.178979
+        # [:, :, 4, 2] = 1.625480
+
+        features = TopNFeatures(2)
+        c1, c2 = features(R)
+        @test R[c1[1]] == R[:, :, 1:1, 1:1]
+        @test R[c2[1]] == R[:, :, 4:4, 1:1]
+        @test R[c1[2]] == R[:, :, 2:2, 2:2]
+        @test R[c2[2]] == R[:, :, 1:1, 2:2]
+
+        features = IndexedFeatures(3, 2)
+        c1, c2 = features(R)
+        @test R[c1[1]] == R[:, :, 3:3, 1:1]
+        @test R[c2[1]] == R[:, :, 2:2, 1:1]
+        @test R[c1[2]] == R[:, :, 3:3, 2:2]
+        @test R[c2[2]] == R[:, :, 2:2, 2:2]
+    end
+end


### PR DESCRIPTION
Originally used in RelavancePropagation.jl's CRP implementation, these are useful to have in XAIBase. 